### PR TITLE
Replace rework/css with PostCSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ describe('your CSS test', function() {
 Barista returns an `object` after your (S)CSS file (or string) has been parsed:
 
 * output.css: A `string` with the rendered CSS.
-* output.data: An `object` containing a parsed CSS tree (powered by [reworkcss/css](https://github.com/reworkcss/css)).
+* output.data: An `object` containing a parsed CSS tree (powered by [PostCSS](https://github.com/postcss/postcss)).
 
 ### output.css
 ```js
@@ -61,65 +61,7 @@ var output = barista({
 });
 ```
 
-`output.data` results:
-```json
-{
-  "type": "stylesheet",
-  "stylesheet": {
-    "rules": [
-      {
-        "type": "rule",
-        "selectors": [
-          "body"
-        ],
-        "declarations": [
-          {
-            "type": "declaration",
-            "property": "background",
-            "value": "#eee",
-            "position": {
-              "start": {
-                "line": 2,
-                "column": 3
-              },
-              "end": {
-                "line": 2,
-                "column": 19
-              }
-            }
-          },
-          {
-            "type": "declaration",
-            "property": "color",
-            "value": "#888",
-            "position": {
-              "start": {
-                "line": 3,
-                "column": 3
-              },
-              "end": {
-                "line": 3,
-                "column": 14
-              }
-            }
-          }
-        ],
-        "position": {
-          "start": {
-            "line": 1,
-            "column": 1
-          },
-          "end": {
-            "line": 4,
-            "column": 2
-          }
-        }
-      }
-    ]
-  }
-}
-```
-
+`output.data` results in a PostCSS AST (abstract syntax tree) node via it's [parse](https://github.com/postcss/postcss/blob/master/lib/postcss.es6#L146) method.
 
 
 ## Options

--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@
 'use strict';
 
 var assign = require('lodash.assign');
-var css = require('css');
 var findRoot = require('find-root');
 var fs = require('fs');
+var postcss = require('postcss');
 var sass = require('node-sass');
 var path = require('path');
 var pathfinder = require('sass-pathfinder');
@@ -93,7 +93,7 @@ Barista.prototype.render = function(options) {
 
   return {
     css: cssData,
-    data: css.parse(cssData),
+    data: postcss.parse(cssData),
     includePaths: sassOptions.includePaths,
     seed: this.options.seedIncludePaths,
   };

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "mocha": "^3.2.0"
   },
   "dependencies": {
-    "css": "2.2.1",
-    "find-root": "^1.0.0",
-    "lodash.assign": "^4.2.0",
+    "find-root": "1.0.0",
+    "lodash.assign": "4.2.0",
     "node-sass": "^3.10.0",
+    "postcss": "5.2.16",
     "sass-pathfinder": "0.0.5"
   }
 }

--- a/test/output.js
+++ b/test/output.js
@@ -43,13 +43,13 @@ describe('barista output', function() {
       assert.equal(expect, true);
     });
 
-    it('should return an parsed CSS tree object', function() {
+    it('should return a PostCSS AST root', function() {
       var styles = '.klass { background: blue };';
       var output = barista({
         content: styles,
       }).data;
 
-      assert.equal(output.type, 'stylesheet');
+      assert.equal(output.type, 'root');
     });
 
     it('should return a CSS tree with a correct selector/property/value structure', function() {
@@ -57,11 +57,11 @@ describe('barista output', function() {
       var output = barista({
         content: styles,
       }).data;
-      var selectorData = output.stylesheet.rules[0];
+      var selectorData = output.nodes[0];
 
-      assert.equal(selectorData.selectors[0], '.klass');
-      assert.equal(selectorData.declarations[0].property, 'background');
-      assert.equal(selectorData.declarations[0].value, 'blue');
+      assert.equal(selectorData.selector, '.klass');
+      assert.equal(selectorData.nodes[0].prop, 'background');
+      assert.equal(selectorData.nodes[0].value, 'blue');
     });
   });
 });


### PR DESCRIPTION
PostCSS's AST is much simpler, and the library appears to be more heavily supported.

https://github.com/postcss/postcss

It might also be easier to use (or create) plugins to hook into PostCSS's methods and AST architecture.

**Minor bump this to v0.1.0 after merging**