### PR TITLE
API: Add `.at()` method for standard testing

### DIFF
--- a/docs/api/rule/at.md
+++ b/docs/api/rule/at.md
@@ -1,0 +1,65 @@
+# .at()
+
+#### .at(mediaQuery)
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| mediaQuery | string / array | The media query to find the CSS rule. |
+
+
+#### Returns
+
+| Type | Description |
+| --- | --- |
+| object | Barista Rule instance described in the media query. `false` if no Rule available. |
+
+
+
+## Usage
+
+Let's pretend the following is our CSS rule:
+
+```scss
+@media tv (min-width: 480px) and (max-width: 960px) and (orientation: landscape) {
+  .vote-pedro { ... }
+}
+@media (min-width: 600px) {
+  .pedro--medieval-warrior { ... }
+}
+```
+
+### Array
+
+Passing media query as an `array` is the easiest way to find your rule.
+
+The values in the `array` work like keywords. The Rule that is returned is the first one to match all of your specified keywords.
+
+```js
+var output = barista({ ... }).mount();
+var rule = output.rule.at(['min', '480px']);
+
+expect(rule.prop('position')).to.equal('absolute');
+```
+
+Although the following example does work, it is best to **avoid** being overly vague with your `.at([])` keywords.
+
+```js
+var output = barista({ ... }).mount();
+var rule = output.rule.at(['4']); // 4 what?! Vote 4 Pedro perhaps?
+
+expect(rule.prop('position')).to.equal('absolute');
+```
+
+
+### String
+
+Passing media query as a `string` allows you to be more specific with your search.
+
+You may omitted parentheses from your `string`. However it must match the **entire** media query. If you have a longer media query, try using an `array` instead.
+
+```js
+var output = barista({ ... }).mount();
+var rule = output.rule.at('min-width: 600px');
+
+expect(rule.prop('display')).to.equal('block');
+```

--- a/docs/api/standard.md
+++ b/docs/api/standard.md
@@ -31,6 +31,7 @@ describe('harry component styles', function() {
 
 ## Standard API
 
+* **[`.at()`](rule/at.md)**
 * **[`.exists()`](rule/exists.md)**
 * **[`.hasProp()`](rule/hasProp.md)**
 * **[`.mediaQuery()`](rule/mq.md)**

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -13,9 +13,13 @@ var isValidString = function(string) {
 var Rule = function(data) {
   if (!data || !data.hasOwnProperty('nodes')) {
     return false;
+  } else if (data && data.type === 'rule') {
+    this.selectors = [data];
+  } else {
+    this.selectors = [];
   }
   this.nodes = data.nodes;
-  this.selectors = [];
+  this.atRules = [];
   return this;
 };
 
@@ -25,6 +29,33 @@ Rule.prototype.create = function(selector) {
   }
   this.find(selector);
   return this;
+};
+
+Rule.prototype.at = function(mediaQuery) {
+  if (!isValidString(mediaQuery) && !Array.isArray(mediaQuery)) {
+    return false;
+  }
+  var selector = false;
+
+  if (typeof mediaQuery === 'string') {
+    // Find by String
+    selector = find(this.atRules, function(rule) {
+      var param = rule.parent.params.toLowerCase().replace(/\(|\)/g, '');
+      var match = mediaQuery.toLowerCase().replace(/\(|\)/g, '');
+
+      return param === match;
+    });
+  }
+  // Find by Array
+  if (Array.isArray(mediaQuery)) {
+    selector = find(this.atRules, function(rule) {
+      var param = rule.parent.params.toLowerCase();
+      var matches = mediaQuery.filter(function(m) { return param.indexOf(m.toLowerCase()) >= 0; });
+      return matches.length === mediaQuery.length;
+    });
+  }
+
+  return selector ? new Rule(selector) : false;
 };
 
 Rule.prototype.getParamNodes = function() {
@@ -62,13 +93,24 @@ Rule.prototype.find = function(selector) {
   }
   // First pass
   var results = this.findSelector(this.nodes, selector);
+  this.findAtRules(selector);
   // Second pass: Media queries
   if (!results.length) {
-    var paramNodes = this.getParamNodes();
-    results = this.findSelector(paramNodes, selector);
+    results = this.atRules;
   }
 
   this.selectors = results;
+  return this;
+};
+
+Rule.prototype.findAtRules = function(selector) {
+  if (!isValidString(selector)) {
+    return false;
+  }
+  var paramNodes = this.getParamNodes();
+  var rules = this.findSelector(paramNodes, selector);
+  this.atRules = rules;
+
   return this;
 };
 

--- a/test/rule.at.js
+++ b/test/rule.at.js
@@ -1,0 +1,71 @@
+// Test :: Rule :: At
+'use strict';
+
+var expect = require('chai').expect;
+var barista = require('../index');
+
+describe('barista output.rule', function() {
+  describe('at', function() {
+    var styles = `
+      .machi {
+        color: red;
+        @media (min-width: 32em) {
+          color: hotpink;
+        }
+        @media (min-width: 42em) {
+          color: rebeccapurple;
+        }
+        @media (min-width: 48em) {
+          color: purple;
+        }
+        @media (min-width: 60em) {
+          color: blue;
+        }
+      }
+    `;
+    var output = barista({
+      content: styles,
+    });
+    var rule = output.rule('.machi');
+
+    it('should return props from a media query', function() {
+      expect(rule.atRules.length).to.equal(4);
+      expect(rule.at('(min-width: 32em)').prop('color')).to.equal('hotpink');
+      expect(rule.at('(min-width: 48em)').prop('color')).to.equal('purple');
+      expect(rule.at('(min-width: 60em)').prop('color')).to.equal('blue');
+    });
+
+    it('should return props from a media query without parentheses', function() {
+      expect(rule.at('min-width: 32em').prop('color')).to.equal('hotpink');
+      expect(rule.at('min-width: 48em').prop('color')).to.equal('purple');
+      expect(rule.at('min-width: 60em').prop('color')).to.equal('blue');
+    });
+
+    it('should return first matched rule a media query array', function() {
+      expect(rule.at(['min']).prop('color')).to.equal('hotpink');
+      expect(rule.at(['32']).prop('color')).to.equal('hotpink');
+      expect(rule.at(['3']).prop('color')).to.equal('hotpink');
+      expect(rule.at(['2']).prop('color')).to.equal('hotpink');
+      expect(rule.at(['42']).prop('color')).to.equal('rebeccapurple');
+    });
+
+    it('should return props from a media query keywords passed as an array', function() {
+      expect(rule.at(['min', '32em']).prop('color')).to.equal('hotpink');
+      expect(rule.at(['min', '48em']).prop('color')).to.equal('purple');
+      expect(rule.at(['min', '60em']).prop('color')).to.equal('blue');
+    });
+
+    it('should return false if media query string is too vague', function() {
+      expect(rule.at('min')).to.be.false
+    });
+
+    it('should return false if media query doesn\'t exist', function() {
+      expect(rule.at('(min-width: 8000000em)')).to.be.false;
+      expect(rule.at('(max-width: 42em)')).to.be.false;
+      expect(rule.at('max-width: 42em')).to.be.false;
+      expect(rule.at(['max', '48em'])).to.be.false;
+      expect(rule.at(['4333px'])).to.be.false;
+      expect(rule.at(['4231', 'max', 'min', 'tv'])).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Updates

This new method allows you to find media queried rules within the output.css.
The `.at()` method accepts either a string (for specific searches) or an array (for keyword based searches).

## .at()

#### .at(mediaQuery)

| Argument | Type | Description |
| --- | --- | --- |
| mediaQuery | string / array | The media query to find the CSS rule. |


#### Returns

| Type | Description |
| --- | --- |
| object | Barista Rule instance described in the media query. `false` if no Rule available. |



## Usage

Let's pretend the following is our CSS rule:

```scss
@media tv (min-width: 480px) and (max-width: 960px) and (orientation: landscape) {
  .vote-pedro { ... }
}
@media (min-width: 600px) {
  .pedro--medieval-warrior { ... }
}
```

### Array

Passing media query as an `array` is the easiest way to find your rule.

The values in the `array` work like keywords. The Rule that is returned is the first one to match all of your specified keywords.

```js
var output = barista({ ... }).mount();
var rule = output.rule.at(['min', '480px']);

expect(rule.prop('position')).to.equal('absolute');
```

Although the following example does work, it is best to **avoid** being overly vague with your `.at([])` keywords.

```js
var output = barista({ ... }).mount();
var rule = output.rule.at(['4']); // 4 what?! Vote 4 Pedro perhaps?

expect(rule.prop('position')).to.equal('absolute');
```


### String

Passing media query as a `string` allows you to be more specific with your search.

You may omitted parentheses from your `string`. However it must match the **entire** media query. If you have a longer media query, try using an `array` instead.

```js
var output = barista({ ... }).mount();
var rule = output.rule.at('min-width: 600px');

expect(rule.prop('display')).to.equal('block');
```

**Changes**

* Add `.at()` method in `Rule` class
* Add tests + docs