### PR TITLE
Add .prop() method for mounted tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ describe('harry component styles', function() {
     var rule = output.find('.your-a-wizard.harry');
 
     expect(rule.length).to.be.above(1);
-    expect(rule.css('background')).to.equal('red');
-    expect(rule.css('color')).to.equal('yellow');
+    expect(rule.prop('background')).to.equal('red');
+    expect(rule.prop('color')).to.equal('yellow');
   });
 });
 ```

--- a/docs/api/mount/find.md
+++ b/docs/api/mount/find.md
@@ -25,15 +25,15 @@ Your `BaristaOutput` instance must first be mounted with `.mount()`.
 
 ## Examples
 
-`.find()` provides a quick way to add and find a jQuery instance of a virtual DOM element. This allows you to use the jQuery's handy `.css()` method to test for CSS rules.
+`.find()` provides a quick way to add and find a jQuery instance of a virtual DOM element. To test it the element's styles, you'll need to use [`.prop()`](/prop.md), which is an alias for jQuery's handy `.css()` method.
 
 ```js
 var output = barista({ ... }).mount();
 var span = output.find('div.kip span.cage-fighter');
 
-expect(span.css('color')).to.equal('red');
-expect(span.css('display')).to.equal('inline-block');
-expect(span.css('position')).to.equal('relative');
+expect(span.prop('color')).to.equal('red');
+expect(span.prop('display')).to.equal('inline-block');
+expect(span.prop('position')).to.equal('relative');
 ```
 
 

--- a/docs/api/mount/prop.md
+++ b/docs/api/mount/prop.md
@@ -1,0 +1,31 @@
+# .prop()
+
+#### .prop(property)
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| property | string | The CSS property to retrieve. |
+
+
+#### Returns
+
+| Type | Description |
+| --- | --- |
+| string | The CSS property retrieved. `false` is property doesn't exist. |
+
+
+#### Aliases
+
+* `css()`
+
+
+
+## Examples
+
+
+```js
+var output = barista({ ... }).mount();
+var rule = output.find('.vote-pedro');
+
+expect(rule.prop('position')).to.equal('absolute');
+```

--- a/docs/api/mount/render.md
+++ b/docs/api/mount/render.md
@@ -25,7 +25,7 @@ Your `BaristaOutput` instance must first be mounted with `.mount()`.
 
 ## Examples
 
-`.render()` provides a quick way to add virtual DOM elements. To test it the element's styles, you'll need to use the jQuery's handy `.css()` method.
+`.render()` provides a quick way to add virtual DOM elements. To test it the element's styles, you'll need to use [`.prop()`](/prop.md), which is an alias for jQuery's handy `.css()` method.
 
 ```js
 var output = barista({ ... }).mount();
@@ -36,9 +36,9 @@ output.render('div.kip span.cage-fighter');
 var span = output.dom.$('div.kip span.cage-fighter');
 
 // Testing the selector's CSS
-expect(span.css('color')).to.equal('red');
-expect(span.css('display')).to.equal('inline-block');
-expect(span.css('position')).to.equal('relative');
+expect(span.prop('color')).to.equal('red');
+expect(span.prop('display')).to.equal('inline-block');
+expect(span.prop('position')).to.equal('relative');
 ```
 
 

--- a/docs/api/mounted.md
+++ b/docs/api/mounted.md
@@ -13,8 +13,8 @@ describe('harry component styles', function() {
     var rule = output.find('.your-a-wizard.harry');
 
     expect(rule.length).to.be.above(1);
-    expect(rule.css('background')).to.equal('red');
-    expect(rule.css('color')).to.equal('yellow');
+    expect(rule.prop('background')).to.equal('red');
+    expect(rule.prop('color')).to.equal('yellow');
   });
 });
 ```
@@ -38,3 +38,4 @@ Barista's Mounted API uses jQuery to retrieve computed CSS styles.
 * **[`.find()`](mount/find.md)**
 * **[`.html()`](mount/html.md)**
 * **[`.render()`](mount/render.md)**
+* **[`.prop()`](mount/prop.md)**

--- a/lib/output.js
+++ b/lib/output.js
@@ -94,6 +94,17 @@ BaristaOutput.prototype.render = function(selectors) {
   return this;
 };
 
+BaristaOutput.prototype.addjQueryMethods = function() {
+  var self = this;
+  if (!this.mounted) {
+    return false;
+  }
+
+  this.dom.$.prototype.prop = this.dom.$.prototype.css;
+
+  return this;
+};
+
 BaristaOutput.prototype.mount = function() {
   this.dom = genki.start({
     content: this.css,
@@ -101,6 +112,8 @@ BaristaOutput.prototype.mount = function() {
   this.window = this.dom.window;
   this.document = this.dom.document;
   this.mounted = true;
+
+  this.addjQueryMethods();
 
   return this;
 };

--- a/test/mount.jQuery.js
+++ b/test/mount.jQuery.js
@@ -1,0 +1,28 @@
+// Test :: Mount :: Prop
+'use strict';
+
+var barista = require('../index');
+var expect = require('chai').expect;
+var sinon = require('sinon');
+
+describe('barista output.mount', function() {
+  describe('.dom.$()', function() {
+    describe('.prop()', function() {
+      it('should be able to get props with .prop()', function() {
+        var styles = `
+          .one {
+            background: blue;
+            color: red;
+          };
+        `;
+        var output = barista({
+          content: styles,
+        }).mount();
+        var rule = output.find('.one');
+
+        expect(rule.prop('background')).to.equal('blue');
+        expect(rule.prop('color')).to.equal('red');
+      });
+    });
+  });
+});

--- a/test/mount.js
+++ b/test/mount.js
@@ -1,4 +1,4 @@
-// Test :: Find
+// Test :: Mount
 'use strict';
 
 var barista = require('../index');


### PR DESCRIPTION
## Updates

`.prop()` is an alias for jQuery's `.css()` method. The reason for adding this is to provide better consistency between standard and mounted APIs.

Resolves: https://github.com/helpscout/seed-barista/issues/18

# .prop()

#### .prop(property)

| Argument | Type | Description |
| --- | --- | --- |
| property | string | The CSS property to retrieve. |


#### Returns

| Type | Description |
| --- | --- |
| string | The CSS property retrieved. `false` is property doesn't exist. |


#### Aliases

* `css()`



## Examples


```js
var output = barista({ ... }).mount();
var rule = output.find('.vote-pedro');

expect(rule.prop('position')).to.equal('absolute');
```
