### PR TITLE
Add srcPaths method to help resolve includePaths + options.src

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,5 @@ logs
 test/
 
 node_modules
+coverage
+.nyc_output

--- a/lib/utils/resolve.js
+++ b/lib/utils/resolve.js
@@ -36,6 +36,14 @@ const seedPaths = (pack = false) => {
   return isString(pack) ? harvester([pack]) : harvester();
 };
 
+const srcPaths = (root = defaultOptions.root, src = '') => {
+  if (!isString(root) || !isString(src)) {
+    return [];
+  }
+
+  return [pathname(root, src)];
+};
+
 const sassPaths = (o = defaultOptions) => {
   const paths = [];
 
@@ -44,6 +52,9 @@ const sassPaths = (o = defaultOptions) => {
   }
   if (hasProp(o, 'includeSeedPaths') && o.includeSeedPaths === true) {
     paths.push(seedPaths(o.pack));
+  }
+  if (hasProp(o, 'src') && hasProp(o, 'root')) {
+    paths.push(srcPaths(o.root, o.src));
   }
 
   return pathfinder(paths);
@@ -54,5 +65,6 @@ module.exports = {
   pathname,
   sassPaths,
   seedPaths,
+  srcPaths,
   stripRoot,
 };

--- a/test/unit/utils/resolve.js
+++ b/test/unit/utils/resolve.js
@@ -75,6 +75,17 @@ describe('utils', () => {
         expect(paths).to.include('root/wee');
         expect(paths[paths.length - 1]).to.include('seed');
       });
+
+      it('should include paths defined in src', () => {
+        const paths = fn({
+          src: 'float',
+          root: 'bear',
+        });
+
+        expect(paths).to.be.an('array');
+        expect(paths).to.have.lengthOf(1);
+        expect(paths[0]).to.include('bear/float');
+      });
     });
 
     describe('.seedPaths()', () => {
@@ -91,6 +102,32 @@ describe('utils', () => {
         expect(paths).to.not.be.empty;
         expect(paths).to.include('hello');
         expect(paths).to.have.lengthOf.at.least(1);
+      });
+    });
+
+    describe('.srcPaths()', () => {
+      const fn = resolve.srcPaths;
+
+      it('should return empty array by default', () => {
+        expect(fn()).to.be.an('array').and.be.empty;
+      });
+
+      it('should return empty array if args are invalid', () => {
+        expect(fn(true, 'awesome')).to.be.an('array').and.be.empty;
+      });
+
+      it('should an array of concatted root + src', () => {
+        const src = fn('root', 'src');
+
+        expect(src).to.be.an('array').and.not.be.empty;
+        expect(src).to.have.lengthOf(1);
+        expect(src[0]).to.equal('root/src');
+      });
+
+      it('should consolidate slashes in root and src', () => {
+        const src = fn('super/root/', 'src.scss');
+
+        expect(src[0]).to.equal('super/root/src.scss');
       });
     });
   });


### PR DESCRIPTION
* Add `srcPaths()` util
* Add tests
* Add coverage ignores to `.npmignore`

Needs to be minor bumped! No changes need on the user's end. No changes for srcs or API 👍 