### PR TITLE
rule.at(x) creates a Barista Rule, even if selector doesn't exist

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -42,7 +42,7 @@ class Rule {
   }
 
   at(keywords) {
-    let selector = false;
+    let selector = '';
 
     if (isString(keywords)) {
       selector = cssom.findSelectorFromParamsByString(this.atRules, keywords);
@@ -50,11 +50,11 @@ class Rule {
       selector = cssom.findSelectorFromParamsByArray(this.atRules, keywords);
     }
 
-    return selector ? new Rule(selector) : false;
+    return new Rule(selector);
   }
 
   exists() {
-    return this.selectors.length > 0;
+    return this.selectors ? this.selectors.length > 0 : false;
   }
 
   hasProp(prop) {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Test helper for Seed CSS",
   "main": "index.js",
   "scripts": {
+    "dev": "npm run test:watch",
     "lint": "jshint index.js lib/",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test:coverage": "nyc --reporter=html --reporter=text mocha test/setup.mocha.js --recursive test/unit test/integration --reporter=dot",

--- a/test/integration/rule.at.js
+++ b/test/integration/rule.at.js
@@ -53,16 +53,16 @@ describe('output.rule', function() {
     });
 
     it('should return false if media query string is too vague', function() {
-      expect(rule.at('min')).to.be.false
+      expect(rule.at('min').exists()).to.be.false
     });
 
     it('should return false if media query doesn\'t exist', function() {
-      expect(rule.at('(min-width: 8000000em)')).to.be.false;
-      expect(rule.at('(max-width: 42em)')).to.be.false;
-      expect(rule.at('max-width: 42em')).to.be.false;
-      expect(rule.at(['max', '48em'])).to.be.false;
-      expect(rule.at(['4333px'])).to.be.false;
-      expect(rule.at(['4231', 'max', 'min', 'tv'])).to.be.false;
+      expect(rule.at('(min-width: 8000000em)').exists()).to.be.false;
+      expect(rule.at('(max-width: 42em)').exists()).to.be.false;
+      expect(rule.at('max-width: 42em').exists()).to.be.false;
+      expect(rule.at(['max', '48em']).exists()).to.be.false;
+      expect(rule.at(['4333px']).exists()).to.be.false;
+      expect(rule.at(['4231', 'max', 'min', 'tv']).exists()).to.be.false;
     });
   });
 });

--- a/test/unit/rule.js
+++ b/test/unit/rule.js
@@ -45,9 +45,9 @@ describe('rule', () => {
     const rule = new Rule(cssData).create('body');
 
     it('should not find rule if keyword is invalid', () => {
-      expect(rule.at('')).to.be.false;
-      expect(rule.at(true)).to.be.false;
-      expect(rule.at(500)).to.be.false;
+      expect(rule.at('').exists()).to.be.false;
+      expect(rule.at(true).exists()).to.be.false;
+      expect(rule.at(500).exists()).to.be.false;
     });
 
     it('should find rule based on string keyword', () => {


### PR DESCRIPTION
This allows for you to write tests for `.exists()` in a consistent way.

Resolves: https://github.com/helpscout/seed-barista/issues/26